### PR TITLE
fix: trim whitespace from IP addresses and usernames in server forms

### DIFF
--- a/apps/dokploy/components/dashboard/settings/servers/handle-servers.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/handle-servers.tsx
@@ -40,15 +40,15 @@ import { toast } from "sonner";
 import { z } from "zod";
 
 const Schema = z.object({
-	name: z.string().min(1, {
+	name: z.string().trim().min(1, {
 		message: "Name is required",
 	}),
 	description: z.string().optional(),
-	ipAddress: z.string().min(1, {
+	ipAddress: z.string().trim().min(1, {
 		message: "IP Address is required",
 	}),
 	port: z.number().optional(),
-	username: z.string().optional(),
+	username: z.string().trim().optional(),
 	sshKeyId: z.string().min(1, {
 		message: "SSH Key is required",
 	}),

--- a/apps/dokploy/components/dashboard/settings/servers/welcome-stripe/create-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/welcome-stripe/create-server.tsx
@@ -30,15 +30,15 @@ import { toast } from "sonner";
 import { z } from "zod";
 
 const Schema = z.object({
-	name: z.string().min(1, {
+	name: z.string().trim().min(1, {
 		message: "Name is required",
 	}),
 	description: z.string().optional(),
-	ipAddress: z.string().min(1, {
+	ipAddress: z.string().trim().min(1, {
 		message: "IP Address is required",
 	}),
 	port: z.number().optional(),
-	username: z.string().optional(),
+	username: z.string().trim().optional(),
 	sshKeyId: z.string().min(1, {
 		message: "SSH Key is required",
 	}),

--- a/apps/dokploy/components/dashboard/settings/web-server/update-server-ip.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/update-server-ip.tsx
@@ -33,7 +33,7 @@ import { toast } from "sonner";
 import { z } from "zod";
 
 const schema = z.object({
-	serverIp: z.string(),
+	serverIp: z.string().trim(),
 });
 
 type Schema = z.infer<typeof schema>;

--- a/packages/server/src/db/schema/server.ts
+++ b/packages/server/src/db/schema/server.ts
@@ -132,7 +132,13 @@ export const apiCreateServer = createSchema
 		username: true,
 		sshKeyId: true,
 	})
-	.required();
+	.required()
+	.extend({
+		ipAddress: z.string().trim().min(1, {
+			message: "IP Address is required",
+		}),
+		username: z.string().trim().optional(),
+	});
 
 export const apiFindOneServer = createSchema
 	.pick({
@@ -159,6 +165,10 @@ export const apiUpdateServer = createSchema
 	.required()
 	.extend({
 		command: z.string().optional(),
+		ipAddress: z.string().trim().min(1, {
+			message: "IP Address is required",
+		}),
+		username: z.string().trim().optional(),
 	});
 
 export const apiUpdateServerMonitoring = createSchema


### PR DESCRIPTION
Add .trim() validation to frontend and backend schemas to prevent SSH connection failures caused by leading/trailing whitespace in IP addresses and usernames.